### PR TITLE
Add scaffold for Vieux Carre imagery portal

### DIFF
--- a/vieux-carre-viewer/.github/workflows/deploy.yml
+++ b/vieux-carre-viewer/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist

--- a/vieux-carre-viewer/.gitignore
+++ b/vieux-carre-viewer/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/vieux-carre-viewer/index.html
+++ b/vieux-carre-viewer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vieux Carre Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/vieux-carre-viewer/package.json
+++ b/vieux-carre-viewer/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "vieux-carre-viewer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "react": "19.1.1",
+    "react-dom": "19.1.1",
+    "react-router-dom": "*",
+    "@tanstack/react-query": "*",
+    "leaflet": "*",
+    "react-leaflet": "*",
+    "three": "*",
+    "@react-three/fiber": "*",
+    "drei": "*",
+    "potree-core": "*",
+    "@mui/material": "*",
+    "@emotion/react": "*",
+    "@emotion/styled": "*"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite-plugin-static-copy": "^1.0.0",
+    "vite-plugin-svgr": "^4.0.0",
+    "typescript": "*",
+    "eslint": "*"
+  }
+}

--- a/vieux-carre-viewer/src/App.tsx
+++ b/vieux-carre-viewer/src/App.tsx
@@ -1,0 +1,14 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import Home from "@/pages/Home";
+import Dataset from "@/pages/Dataset";
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route index element={<Home />} />
+        <Route path="dataset/:id" element={<Dataset />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/vieux-carre-viewer/src/components/AccuracyPanel.tsx
+++ b/vieux-carre-viewer/src/components/AccuracyPanel.tsx
@@ -1,0 +1,3 @@
+export default function AccuracyPanel() {
+  return <div>Accuracy Info</div>;
+}

--- a/vieux-carre-viewer/src/components/MapViewer.tsx
+++ b/vieux-carre-viewer/src/components/MapViewer.tsx
@@ -1,0 +1,11 @@
+import { MapContainer, TileLayer } from "react-leaflet";
+
+export default function MapViewer({ center=[29.9584,-90.0644], zoom=16 }) {
+  return (
+    <MapContainer center={center} zoom={zoom} style={{height:"100%",width:"100%"}}>
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="© OSM contributors" />
+    </MapContainer>
+  );
+}

--- a/vieux-carre-viewer/src/components/ModelViewer.tsx
+++ b/vieux-carre-viewer/src/components/ModelViewer.tsx
@@ -1,0 +1,3 @@
+export default function ModelViewer() {
+  return <div>Model Viewer Placeholder</div>;
+}

--- a/vieux-carre-viewer/src/components/PointCloudViewer.tsx
+++ b/vieux-carre-viewer/src/components/PointCloudViewer.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { Potree } from "potree-core";
+
+export function PointCloudViewer({ url }: { url: string }) {
+  const el = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!el.current) return;
+    const viewer = new Potree.Viewer(el.current);
+    viewer.setEDLEnabled(true);
+    viewer.loadPointCloud(url, "cloud", e => {
+      viewer.scene.view.position.set(0,0,50);
+      viewer.fitToScreen();
+    });
+    return () => viewer.dispose();
+  }, [url]);
+
+  return <div ref={el} className="w-full h-full"></div>;
+}

--- a/vieux-carre-viewer/src/hooks/useFetchJson.ts
+++ b/vieux-carre-viewer/src/hooks/useFetchJson.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+export function useFetchJson<T>(url: string) {
+  return useQuery({
+    queryKey: [url],
+    queryFn: async () => {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Network response was not ok");
+      return res.json() as Promise<T>;
+    }
+  });
+}

--- a/vieux-carre-viewer/src/main.tsx
+++ b/vieux-carre-viewer/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles/globals.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vieux-carre-viewer/src/pages/Dataset.tsx
+++ b/vieux-carre-viewer/src/pages/Dataset.tsx
@@ -1,0 +1,6 @@
+import { useParams } from "react-router-dom";
+
+export default function Dataset() {
+  const { id } = useParams();
+  return <div>Dataset: {id}</div>;
+}

--- a/vieux-carre-viewer/src/pages/Home.tsx
+++ b/vieux-carre-viewer/src/pages/Home.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Welcome to Vieux Carre Viewer</div>;
+}

--- a/vieux-carre-viewer/src/styles/globals.css
+++ b/vieux-carre-viewer/src/styles/globals.css
@@ -1,0 +1,2 @@
+@import "leaflet/dist/leaflet.css";
+html,body,#root{height:100%;margin:0}

--- a/vieux-carre-viewer/tsconfig.json
+++ b/vieux-carre-viewer/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/vieux-carre-viewer/tsconfig.node.json
+++ b/vieux-carre-viewer/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vieux-carre-viewer/vite.config.ts
+++ b/vieux-carre-viewer/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    viteStaticCopy({
+      targets: [{ src: "public/data/**/*", dest: "data" }]
+    })
+  ]
+});


### PR DESCRIPTION
## Summary
- add Vite+React skeleton for the Vieux Carré imagery portal
- include Leaflet viewer and Potree bootstrap
- set up deployment workflow

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_688a314fa9a08328bc6ca7a5d98b5b60